### PR TITLE
feat: add CUDA-enabled ollama recipe for Tegra

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -14,3 +14,7 @@
 	path = meta-tegra-community
 	url = https://github.com/OE4T/meta-tegra-community.git
 	branch = scarthgap-l4t-r35.x
+[submodule "meta-lts-mixins"]
+	path = meta-lts-mixins
+	url = https://git.yoctoproject.org/meta-lts-mixins
+	branch = scarthgap/go

--- a/meta-bmj/conf/templates/bmj/bblayers.conf.sample
+++ b/meta-bmj/conf/templates/bmj/bblayers.conf.sample
@@ -17,5 +17,6 @@ BBLAYERS ?= " \
   ${BSPDIR}/meta-openembedded/meta-filesystems \
   ${BSPDIR}/meta-tegra-community \
   ${BSPDIR}/meta-tegra-support \
+  ${BSPDIR}/meta-lts-mixins \
   ${BSPDIR}/meta-bmj \
   "

--- a/meta-bmj/recipes-bmj/images/bmj-image-ml.bb
+++ b/meta-bmj/recipes-bmj/images/bmj-image-ml.bb
@@ -10,7 +10,7 @@ REQUIRED_DISTRO_FEATURES = "opengl"
 
 CORE_IMAGE_BASE_INSTALL += " \
     packagegroup-core \
-    packagegroup-cuda \
+    packagegroup-cuda-dev \
     packagegroup-devtools \
     nv-tegra-release \
 "

--- a/meta-bmj/recipes-bmj/ollama/ollama/0001-cmake-drop-cross-unsupported-RUNTIME_DEPENDENCIES.patch
+++ b/meta-bmj/recipes-bmj/ollama/ollama/0001-cmake-drop-cross-unsupported-RUNTIME_DEPENDENCIES.patch
@@ -1,0 +1,41 @@
+Subject: [PATCH] cmake: drop cross-unsupported RUNTIME_DEPENDENCIES installs
+
+install(TARGETS ... RUNTIME_DEPENDENCIES ...) is rejected at configure time
+when cross-compiling. Drop it from the CPU and CUDA installs (the CUDA runtime
+is provided by RDEPENDS, not bundled), and drop ollama's duplicate
+add_subdirectory(ggml-cuda) which ggml_add_backend(CUDA) already does.
+
+Upstream-Status: Inappropriate [oe cross-compile packaging]
+---
+ src/github.com/ollama/ollama/CMakeLists.txt | 12 ------------
+ 1 file changed, 12 deletions(-)
+
+diff --git a/src/github.com/ollama/ollama/CMakeLists.txt b/src/github.com/ollama/ollama/CMakeLists.txt
+--- a/src/github.com/ollama/ollama/CMakeLists.txt
++++ b/src/github.com/ollama/ollama/CMakeLists.txt
+@@ -101,8 +101,6 @@ endforeach()
+ endforeach()
+ 
+ install(TARGETS ggml-base ${CPU_VARIANTS}
+-    RUNTIME_DEPENDENCIES
+-        PRE_EXCLUDE_REGEXES ".*"
+     RUNTIME DESTINATION ${OLLAMA_INSTALL_DIR} COMPONENT CPU
+     LIBRARY DESTINATION ${OLLAMA_INSTALL_DIR} COMPONENT CPU
+     FRAMEWORK DESTINATION ${OLLAMA_INSTALL_DIR} COMPONENT CPU
+@@ -115,16 +113,6 @@ if(CMAKE_CUDA_COMPILER)
+     endif()
+ 
+     find_package(CUDAToolkit)
+-    add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/ml/backend/ggml/ggml/src/ggml-cuda)
+-    target_include_directories(ggml-cuda PRIVATE ${GGML_INCLUDE_DIRS})
+-    install(TARGETS ggml-cuda
+-        RUNTIME_DEPENDENCIES
+-            DIRECTORIES ${CUDAToolkit_BIN_DIR} ${CUDAToolkit_BIN_DIR}/x64 ${CUDAToolkit_LIBRARY_DIR}
+-            PRE_INCLUDE_REGEXES cublas cublasLt cudart
+-            PRE_EXCLUDE_REGEXES ".*"
+-        RUNTIME DESTINATION ${OLLAMA_INSTALL_DIR} COMPONENT CUDA
+-        LIBRARY DESTINATION ${OLLAMA_INSTALL_DIR} COMPONENT CUDA
+-    )
+ endif()
+ 
+ set(WINDOWS_AMDGPU_TARGETS_EXCLUDE_REGEX "^gfx(908|90a|1200|1201):xnack[+-]$"

--- a/meta-bmj/recipes-bmj/ollama/ollama/ollama.service
+++ b/meta-bmj/recipes-bmj/ollama/ollama/ollama.service
@@ -1,0 +1,16 @@
+[Unit]
+Description=Ollama Service
+Wants=network-online.target
+After=network-online.target
+
+[Service]
+ExecStart=/usr/bin/ollama serve
+User=ollama
+Group=ollama
+Restart=always
+RestartSec=3
+Environment="OLLAMA_MODELS=/var/lib/ollama/models"
+StateDirectory=ollama
+
+[Install]
+WantedBy=multi-user.target

--- a/meta-bmj/recipes-bmj/ollama/ollama_0.21.0.bb
+++ b/meta-bmj/recipes-bmj/ollama/ollama_0.21.0.bb
@@ -1,0 +1,87 @@
+SUMMARY = "Get up and running with Llama, Mistral, Gemma, and other LLMs"
+HOMEPAGE = "https://ollama.com"
+LICENSE = "MIT"
+LIC_FILES_CHKSUM = "file://src/${GO_IMPORT}/LICENSE;md5=a8abe7311c869aba169d640cf367a4af"
+
+GO_IMPORT = "github.com/ollama/ollama"
+SRC_URI = "git://${GO_IMPORT}.git;protocol=https;branch=main \
+           file://0001-cmake-drop-cross-unsupported-RUNTIME_DEPENDENCIES.patch \
+           file://ollama.service"
+SRCREV = "57653b8e42d69ec35f68a59857bad4d0f07994a3"
+
+CUDA_VERSION = "11.8"
+
+inherit cmake cuda go-mod systemd useradd
+
+CUDA_NATIVEDEPS = "cuda-compiler-11-8-native cuda-cudart-11-8-native"
+
+DEPENDS += "cmake-native cuda-cudart-11-8 libcublas-11-8 cuda-nvcc-11-8 cuda-driver-11-8 gcc-for-nvcc"
+RDEPENDS:${PN} += "cuda-cudart-11-8 libcublas-11-8 cuda-driver-11-8"
+
+OECMAKE_SOURCEPATH = "${S}/src/${GO_IMPORT}"
+
+EXTRA_OECMAKE += "-DGGML_CUDA=ON \
+                  -DCMAKE_SKIP_BUILD_RPATH=ON \
+                  -DCMAKE_BUILD_WITH_INSTALL_RPATH=ON"
+
+# nvcc honours NVCC_PREPEND_FLAGS before all other args, so use it to give the
+# compiler-id probe a --sysroot and the cuda-compat-workarounds shim.
+export NVCC_PREPEND_FLAGS = "-Xcompiler --sysroot=${RECIPE_SYSROOT} -Xcompiler -isystem${RECIPE_SYSROOT}/usr/include/cuda-compat-workarounds --library-path ${RECIPE_SYSROOT}/usr/local/cuda-${CUDA_VERSION}/${baselib} --library-path ${RECIPE_SYSROOT}/usr/local/cuda-${CUDA_VERSION}/${baselib}/stubs"
+
+# cuda.bbclass writes a bare `set(CMAKE_CUDA_COMPILER nvcc)`; give it an
+# absolute path. Host compiler and --sysroot come from the class's exported
+# CUDAHOSTCXX / CUDAFLAGS.
+OECMAKE_CUDA_COMPILER = "${CUDA_TOOLKIT_ROOT}/bin/nvcc"
+
+# Compose go's + cmake's configure (go-mod's EXPORT_FUNCTIONS overrides cmake's).
+do_configure() {
+    go_do_configure
+    cmake_do_configure
+}
+
+export GOPROXY = "https://proxy.golang.org,direct"
+do_compile[network] = "1"
+
+do_compile() {
+    cmake_runcmake_build
+
+    cd ${OECMAKE_SOURCEPATH}
+    export TMPDIR="${GOTMPDIR}"
+    export CGO_ENABLED=1
+    export CGO_LDFLAGS="${CGO_LDFLAGS} -L${B}/lib/ollama -Wl,-rpath,${libdir}/ollama"
+    ${GO} build ${GOBUILDFLAGS} -o ${B}/ollama .
+}
+
+do_install() {
+    install -d ${D}${libdir}/ollama
+    cp -a ${B}/lib/ollama/. ${D}${libdir}/ollama/
+    chown -R root:root ${D}${libdir}/ollama
+
+    install -d ${D}${bindir}
+    install -m 0755 ${B}/ollama ${D}${bindir}/ollama
+
+    install -d ${D}${systemd_system_unitdir}
+    install -m 0644 ${WORKDIR}/ollama.service ${D}${systemd_system_unitdir}/
+}
+
+FILES:${PN} += "${libdir}/ollama \
+                ${systemd_system_unitdir}/ollama.service"
+
+SYSTEMD_SERVICE:${PN} = "ollama.service"
+SYSTEMD_AUTO_ENABLE:${PN} = "enable"
+
+USERADD_PACKAGES = "${PN}"
+# No -m: /var/lib/ollama is created by StateDirectory=ollama in the unit.
+USERADD_PARAM:${PN}  = "-r -s /bin/false -d /var/lib/ollama -g ollama -G video ollama"
+GROUPADD_PARAM:${PN} = "-r ollama"
+
+# dev-so: dlopen()ed ggml plugins ship in the runtime package with their .so
+# symlinks. already-stripped/textrel/buildpaths: unavoidable for nvcc output.
+INSANE_SKIP:${PN} += "textrel already-stripped dev-so buildpaths"
+
+# cuda-cudart/libcublas 11.4 and 11-8 both provide these SONAMEs; RDEPENDS
+# already pins the 11-8 variants.
+PRIVATE_LIBS:${PN} = "libcudart.so.11.0 libcublas.so.11 libcublasLt.so.11"
+
+COMPATIBLE_MACHINE = "(tegra)"
+


### PR DESCRIPTION
Build ollama's ggml CUDA backend on CUDA 11.8